### PR TITLE
:sparkles: Add language-codes-standardizations

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -585,6 +585,42 @@ files = [
 colors = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "langcodes"
+version = "3.4.1"
+description = "Tools for labeling human languages with IETF language tags"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "langcodes-3.4.1-py3-none-any.whl", hash = "sha256:68f686fc3d358f222674ecf697ddcee3ace3c2fe325083ecad2543fd28a20e77"},
+    {file = "langcodes-3.4.1.tar.gz", hash = "sha256:a24879fed238013ac3af2424b9d1124e38b4a38b2044fd297c8ff38e5912e718"},
+]
+
+[package.dependencies]
+language-data = ">=1.2"
+
+[package.extras]
+build = ["build", "twine"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "language-data"
+version = "1.2.0"
+description = "Supplementary data about languages used by the langcodes module"
+optional = false
+python-versions = "*"
+files = [
+    {file = "language_data-1.2.0-py3-none-any.whl", hash = "sha256:77d5cab917f91ee0b2f1aa7018443e911cf8985ef734ca2ba3940770f6a3816b"},
+    {file = "language_data-1.2.0.tar.gz", hash = "sha256:82a86050bbd677bfde87d97885b17566cfe75dad3ac4f5ce44b52c28f752e773"},
+]
+
+[package.dependencies]
+marisa-trie = ">=0.7.7"
+
+[package.extras]
+build = ["build", "twine"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "litestar"
 version = "2.12.1"
 description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
@@ -627,6 +663,109 @@ redis = ["redis[hiredis] (>=4.4.4)"]
 sqlalchemy = ["advanced-alchemy (>=0.2.2)"]
 standard = ["fast-query-parsers (>=1.0.2)", "jinja2", "jsbeautifier", "uvicorn[standard]", "uvloop (>=0.18.0)"]
 structlog = ["structlog"]
+
+[[package]]
+name = "marisa-trie"
+version = "1.2.0"
+description = "Static memory-efficient and fast Trie-like structures for Python."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "marisa_trie-1.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:61fab91fef677f0af0e818e61595f2334f7e0b3e122b24ec65889aae69ba468d"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5f5b3080316de735bd2b07265de5eea3ae176fa2fc60f9871aeaa9cdcddfc8f7"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:77bfde3287314e91e28d3a882c7b87519ef0ee104c921df72c7819987d5e4863"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4fbb1ec1d9e891060a0aee9f9c243acec63de1e197097a14850ba38ec8a4013"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e04e9c86fe8908b61c2aebb8444217cacaed15b93d2dccaac3849e36a6dc660"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a7c75a508f44e40f7af8448d466045a97534adcbb026e63989407cefb9ebfa6"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5321211647609869907e81b0230ad2dfdfa7e19fe1ee469b46304a622391e6a1"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:88660e6ee0f821872aaf63ba4b9a7513428b9cab20c69cc013c368bd72c3a4fe"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e4535fc5458de2b59789e574cdd55923d63de5612dc159d33941af79cd62786"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-win32.whl", hash = "sha256:bdd1d4d430e33abbe558971d1bd57da2d44ca129fa8a86924c51437dba5cb345"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:c729e2b8f9699874b1372b5a01515b340eda1292f5e08a3fe4633b745f80ad7a"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d62985a0e6f2cfeb36cd6afa0460063bbe83ef4bfd9afe189a99103487547210"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1890cc993149db4aa8242973526589e8133c3f92949b0ac74c2c9a6596707ae3"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26177cd0dadb7b44f47c17c40e16ac157c4d22ac7ed83b5a47f44713239e10d1"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3425dc81d49a374be49e3a063cb6ccdf57973201b0a30127082acea50562a85e"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:525b8df41a1a7337ed7f982eb63b704d7d75f047e30970fcfbe9cf6fc22c5991"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c643c66bbde6a115e4ec8713c087a9fe9cb7b7c684e6af4cf448c120fa427ea4"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5a83fe83e0eab9154a2dc7c556898c86584b7779ddf4214c606fce4ceff07c13"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:49701db6bb8f1ec0133abd95f0a4891cfd6f84f3bd019e343037e31a5a5b0210"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a3f0562863deaad58c5dc3a51f706da92582bc9084189148a45f7a12fe261a51"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-win32.whl", hash = "sha256:b08968ccad00f54f31e38516e4452fae59dd15a3fcee56aea3101ba2304680b3"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3ef375491e7dd71a0a7e7bf288c88750942bd1ee0c379dcd6ad43e31af67d00"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:39b88f126988ea83e8458259297d2b2f9391bfba8f4dc5d7a246813aae1c1def"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ec167b006884a90d130ee30518a9aa44cb40211f702bf07031b2d7d4d1db569b"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b855e6286faef5411386bf9d676dfb545c09f7d109f197f347c9366aeb12f07"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cd287ff323224d87c2b739cba39614aac3737c95a254e0ff70e77d9b8df226d"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d8a1c0361165231f4fb915237470afc8cc4803c535f535f4fc42ca72855b124"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3267f438d258d7d85ee3dde363c4f96c3196ca9cd9e63fe429a59543cc544b15"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c87a0c2cccce12b07bfcb70708637c0816970282d966a1531ecda1a24bd1cc8"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d3c0e38f0501951e2322f7274a39b8e2344bbd91ceaa9da439f46022570ddc9d"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cd88a338c87e6dc130b6cea7b697580c21f0c83a8a8b46671cfecbb713d3fe24"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-win32.whl", hash = "sha256:5cea60975184f03fbcff51339df0eb44d2abe106a1693983cc64415eb87b897b"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b04a07b99b62b9bdf3eaf1d44571a3293ce249ce8971944e780c9c709593462f"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c11af35d9304de420b359741e12b885d04f11403697efcbbe8cb50f834261ebc"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2db8e74493c3bffb480c54afaa88890a39bf90063ff5b322acf64bf076e4b36e"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9bcc6613bc873136dc62609b66aaa27363e2bd46c03fdab62d638f7cf69d5f82"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5cb731581effb3e05258f3ddc2a155475de74bb00f61eb280f991e13b48f783"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:eba1061bbeaeec4149282beab2ae163631606f119f549a10246b014e13f9047b"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:015594427360c6ad0fa94d51ee3d50fb83b0f7278996497fd2d69f877c3de9bd"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:36d65bcbf22a70cdd0202bd8608c2feecc58bdb9e5dd9a2f5a723b651fcab287"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-win32.whl", hash = "sha256:bc138625b383998f5cd0cbf6cd38d66d414f3786ae6d7b4e4a6fc970140ef4e9"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:27d270a64eb655754dfb4e352c60a084b16ab999b3a97a0cdc7dbecbca3c0e35"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fa1fa7f67d317a921315a65e266b9e156ce5a956076ec2b6dbf72d67c7df8216"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9dccef41d4af11a03558c1d101de58bd723b3039a5bc4e064250008c118037ec"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:873efd212dfef2b736ff2ff43e10b348c428d5dbac7b8cb8aa777004bc8c7b0e"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8af7a21ac2ba6dc23e4257fc3a40b3070e776275d3d0b5b2ef44473ad92caf3a"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7202ba0ca1db5245feaebbeb3d0c776b2da1fffb0abc3500dd505f679686aa1"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83d90be28c083323909d23ff8e9b4a2764b9e75520d1bae1a277e9fa7ca20d15"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:40e2a374026492ac84232897f1f1d8f92a4a1f8bcf3f0ded1f2b8b708d1acfff"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:7c6e6506bd24a5799b9b4b9cf1e8d6fa281f136396ba018a95d95d4d74715227"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:437bf6c0d7ba4cf17656a0e3bdd0b3c2c92c01fedfa670904177eef3116a4f45"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-win32.whl", hash = "sha256:6aeef7b364fb3b34dbba1cc57b79f1668fad0c3f039738d65a5b0d5ddce15f47"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:02f773e85cc566a24c0e0e28c744052db7691c4f13d02e4257bc657a49b9ab14"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6ff705cb3b907bdeacb8c4b3bf0541691f52b101014d189a707ca41ebfacad59"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:006419c59866979188906babc42ae0918081c18cabc2bdabca027f68c081c127"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7196691681ecb8a12629fb6277c33bafdb27cf2b6c18c28bc48fa42a15eab8f"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaf052c0a1f4531ee12fd4c637212e77ad2af8c3b38a0d3096622abd01a22212"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb95f3ab95ba933f6a2fa2629185e9deb9da45ff2aa4ba8cc8f722528c038ef"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7459b1e1937e33daed65a6d55f8b95f9a8601f4f8749d01641cf548ecac03840"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:902ea948677421093651ca98df62d255383f865f7c353f956ef666e92500e79f"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:fdf7a2d066907816726f3bf241b8cb05b698d6ffaa3c5ea2658d4ba69e87ec57"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3540bb85b38dfc17060263e061c95a0a435681b04543d1ae7e8d7441a9790593"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-win32.whl", hash = "sha256:fe1394e1f262e5b45d22d30bd1ef75174d1f2772e86716b5f93f9c29dfc1a779"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:84c44cb13803723f0f76aa2ba1a657f762a0bb9d8a9b80dfff249bb1c3218dd6"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:035c4c8f3b313b4d7b7451ddd539da811a11077a9e359c6a0345f816b1bdccb3"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d4f05c2ee218a5ab09d269b640d06f9708b0cf37c842344cbdffb0661c74c472"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92ac63e1519598de946c7d9346df3bb52ed96968eb3021b4e89b51d79bc72a86"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:045f32eaeb5dcdb5beadb571ba616d7a34141764b616eebb4decce71b366f5fa"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb60c2f9897ce2bfc31a69ac25a040de4f8643ab2a339bb0ff1185e1a9dedaf8"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f19c5fcf23c02f1303deb69c67603ee37ed8f01de2d8b19f1716a6cf5afd5455"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a06a77075240eb83a47b780902322e66c968a06a2b6318cab06757c65ea64190"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:125016400449e46ec0e5fabd14c8314959c4dfa02ffc2861195c99efa2b5b011"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c57647dd9f9ba16fc5bb4679c915d7d48d5c0b25134fb10f095ccd839686a027"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6601e74338fb31e1b20674257706150113463182a01d3a1310df6b8840720b17"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ce2f68e1000c4c72820c5b2c9d037f326fcf75f036453a5e629f225f99b92cfc"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:069ac10a133d96b3f3ed1cc071b973a3f28490345e7941c778a1d81cf176f04a"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:de9911480ce2a0513582cb84ee4484e5ee8791e692276c7f5cd7378e114d1988"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cfec001cf233e8853a29e1c2bb74031c217aa61e7bd19389007e04861855731"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd1f3ef8de89684fbdd6aaead09d53b82e718bad4375d2beb938cbd24b48c51a"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65f5d8c1ecc85283b5b03a1475a5da723b94b3beda752c895b2f748477d8f1b1"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:2e7540f844c1de493a90ad7d0f5bffc6a2cba19fe312d6db7b97aceff11d97f8"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2fb9243f66563285677079c9dccc697d35985287bacb36c8e685305687b0e025"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:58e2b84cbb6394f9c567f1f4351fc2995a094e1b684da9b577d4139b145401d6"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b4a8d3ed1f1b8f551b52e11a1265eaf0718f06bb206654b2c529cecda0913dd"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97652c5fbc92f52100afe1c4583625015611000fa81606ad17f1b3bbb9f3bfa"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7183d84da20c89b2a366bf581f0d79d1e248909678f164e8536f291120432e8"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c7f4df4163202b0aa5dad3eeddf088ecb61e9101986c8b31f1e052ebd6df9292"},
+    {file = "marisa_trie-1.2.0.tar.gz", hash = "sha256:fedfc67497f8aa2757756b5cf493759f245d321fb78914ce125b6d75daa89b5f"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[package.extras]
+test = ["hypothesis", "pytest", "readme-renderer"]
 
 [[package]]
 name = "markdown-it-py"
@@ -1031,6 +1170,17 @@ msgspec = ["msgspec"]
 odmantic = ["odmantic (<1.0.0)", "pydantic[email]"]
 pydantic = ["pydantic[email]"]
 sqlalchemy = ["sqlalchemy (>=1.4.29)"]
+
+[[package]]
+name = "pycountry"
+version = "24.6.1"
+description = "ISO country, subdivision, language, currency and script definitions and their translations"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycountry-24.6.1-py3-none-any.whl", hash = "sha256:f1a4fb391cd7214f8eefd39556d740adcc233c778a27f8942c8dca351d6ce06f"},
+    {file = "pycountry-24.6.1.tar.gz", hash = "sha256:b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221"},
+]
 
 [[package]]
 name = "pydantic"
@@ -2016,4 +2166,4 @@ test = ["Cython (>=0.29.36,<0.30.0)", "aiohttp (==3.9.0b0)", "aiohttp (>=3.8.1)"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "db153c1fd3bf5f78ac6dc2cb5247364133d44b04189bfdc320214d6a717f4fef"
+content-hash = "f94125f193fcc5274c0419415d16214b42a1d32966901af86636db524f9b23a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ fasttext-predict = "^0.9.2.2"
 uvloop = { version = "^0.20.0", markers = "sys_platform != 'win32'" }
 picologging = "^0.9.3"
 granian = "^1.6.0"
+pycountry = "^24.6.1"
+langcodes = "^3.4.1"
 
 [tool.poetry.group.cuda.dependencies]
 nvidia-cublas-cu12 = "^12.6.1.4"

--- a/server/api/v4/__init__.py
+++ b/server/api/v4/__init__.py
@@ -2,5 +2,6 @@ from litestar import Router
 
 from server.api.v4.index import index
 from server.api.v4.language import language
+from server.api.v4.languages import languages
 
-v4 = Router('/v4', tags=['v4'], route_handlers=[index, language])
+v4 = Router('/v4', tags=['v4'], route_handlers=[index, language, languages])

--- a/server/api/v4/languages.py
+++ b/server/api/v4/languages.py
@@ -1,0 +1,332 @@
+from litestar import Litestar, get
+from litestar.params import Parameter
+from litestar.openapi.spec.example import Example
+from typing import Annotated, List, Optional, Dict, Union
+import pycountry
+import langcodes
+from server.types import Languages
+from server.types import Standardization
+
+# List of FLORES-200 codes
+flores_codes: List[Languages] = [
+    'ace_Arab',
+    'ace_Latn',
+    'acm_Arab',
+    'acq_Arab',
+    'aeb_Arab',
+    'afr_Latn',
+    'ajp_Arab',
+    'aka_Latn',
+    'amh_Ethi',
+    'apc_Arab',
+    'arb_Arab',
+    'arb_Latn',
+    'ars_Arab',
+    'ary_Arab',
+    'arz_Arab',
+    'asm_Beng',
+    'ast_Latn',
+    'awa_Deva',
+    'ayr_Latn',
+    'azb_Arab',
+    'azj_Latn',
+    'bak_Cyrl',
+    'bam_Latn',
+    'ban_Latn',
+    'bel_Cyrl',
+    'bem_Latn',
+    'ben_Beng',
+    'bho_Deva',
+    'bjn_Arab',
+    'bjn_Latn',
+    'bod_Tibt',
+    'bos_Latn',
+    'bug_Latn',
+    'bul_Cyrl',
+    'cat_Latn',
+    'ceb_Latn',
+    'ces_Latn',
+    'cjk_Latn',
+    'ckb_Arab',
+    'crh_Latn',
+    'cym_Latn',
+    'dan_Latn',
+    'deu_Latn',
+    'dik_Latn',
+    'dyu_Latn',
+    'dzo_Tibt',
+    'ell_Grek',
+    'eng_Latn',
+    'epo_Latn',
+    'est_Latn',
+    'eus_Latn',
+    'ewe_Latn',
+    'fao_Latn',
+    'fij_Latn',
+    'fin_Latn',
+    'fon_Latn',
+    'fra_Latn',
+    'fur_Latn',
+    'fuv_Latn',
+    'gla_Latn',
+    'gle_Latn',
+    'glg_Latn',
+    'grn_Latn',
+    'guj_Gujr',
+    'hat_Latn',
+    'hau_Latn',
+    'heb_Hebr',
+    'hin_Deva',
+    'hne_Deva',
+    'hrv_Latn',
+    'hun_Latn',
+    'hye_Armn',
+    'ibo_Latn',
+    'ilo_Latn',
+    'ind_Latn',
+    'isl_Latn',
+    'ita_Latn',
+    'jav_Latn',
+    'jpn_Jpan',
+    'kab_Latn',
+    'kac_Latn',
+    'kam_Latn',
+    'kan_Knda',
+    'kas_Arab',
+    'kas_Deva',
+    'kat_Geor',
+    'knc_Arab',
+    'knc_Latn',
+    'kaz_Cyrl',
+    'kbp_Latn',
+    'kea_Latn',
+    'khm_Khmr',
+    'kik_Latn',
+    'kin_Latn',
+    'kir_Cyrl',
+    'kmb_Latn',
+    'kmr_Latn',
+    'kon_Latn',
+    'kor_Hang',
+    'lao_Laoo',
+    'lij_Latn',
+    'lim_Latn',
+    'lin_Latn',
+    'lit_Latn',
+    'lmo_Latn',
+    'ltg_Latn',
+    'ltz_Latn',
+    'lua_Latn',
+    'lug_Latn',
+    'luo_Latn',
+    'lus_Latn',
+    'lvs_Latn',
+    'mag_Deva',
+    'mai_Deva',
+    'mal_Mlym',
+    'mar_Deva',
+    'min_Arab',
+    'min_Latn',
+    'mkd_Cyrl',
+    'plt_Latn',
+    'mlt_Latn',
+    'mni_Beng',
+    'khk_Cyrl',
+    'mos_Latn',
+    'mri_Latn',
+    'mya_Mymr',
+    'nld_Latn',
+    'nno_Latn',
+    'nob_Latn',
+    'npi_Deva',
+    'nso_Latn',
+    'nus_Latn',
+    'nya_Latn',
+    'oci_Latn',
+    'gaz_Latn',
+    'ory_Orya',
+    'pag_Latn',
+    'pan_Guru',
+    'pap_Latn',
+    'pes_Arab',
+    'pol_Latn',
+    'por_Latn',
+    'prs_Arab',
+    'pbt_Arab',
+    'quy_Latn',
+    'ron_Latn',
+    'run_Latn',
+    'rus_Cyrl',
+    'sag_Latn',
+    'san_Deva',
+    'sat_Olck',
+    'scn_Latn',
+    'shn_Mymr',
+    'sin_Sinh',
+    'slk_Latn',
+    'slv_Latn',
+    'smo_Latn',
+    'sna_Latn',
+    'snd_Arab',
+    'som_Latn',
+    'sot_Latn',
+    'spa_Latn',
+    'als_Latn',
+    'srd_Latn',
+    'srp_Cyrl',
+    'ssw_Latn',
+    'sun_Latn',
+    'swe_Latn',
+    'swh_Latn',
+    'szl_Latn',
+    'tam_Taml',
+    'tat_Cyrl',
+    'tel_Telu',
+    'tgk_Cyrl',
+    'tgl_Latn',
+    'tha_Thai',
+    'tir_Ethi',
+    'taq_Latn',
+    'taq_Tfng',
+    'tpi_Latn',
+    'tsn_Latn',
+    'tso_Latn',
+    'tuk_Latn',
+    'tum_Latn',
+    'tur_Latn',
+    'twi_Latn',
+    'tzm_Tfng',
+    'uig_Arab',
+    'ukr_Cyrl',
+    'umb_Latn',
+    'urd_Arab',
+    'uzn_Latn',
+    'vec_Latn',
+    'vie_Latn',
+    'war_Latn',
+    'wol_Latn',
+    'xho_Latn',
+    'ydd_Hebr',
+    'yor_Latn',
+    'yue_Hant',
+    'zho_Hans',
+    'zho_Hant',
+    'zsm_Latn',
+    'zul_Latn',
+]
+
+# Helper function to get codes using pycountry and langcodes
+def get_language_codes(flores_code: str) -> Dict[str, str]:
+    codes = {}
+    try:
+        # Parse the FLORES-200 code
+        iso6393_code, iso15924_code = flores_code.split('_')
+        codes['FLORES-200'] = flores_code
+        codes['ISO-639-3'] = iso6393_code
+        codes['ISO-15924'] = iso15924_code
+
+        # Get the language name from ISO-639-3 code
+        lang = pycountry.languages.get(alpha_3=iso6393_code)
+        if lang is None:
+            # Try to lookup using other methods
+            lang = pycountry.languages.lookup(iso6393_code)
+        if lang:
+            codes['name'] = lang.name
+            # ISO-639-1
+            codes['ISO-639-1'] = getattr(lang, 'alpha_2', '')
+            # ISO 639-2
+            codes['ISO-639-2/B'] = getattr(lang, 'bibliographic', '')
+            # IETF-BCP-47
+            codes['IETF-BCP-47'] = langcodes.standardize_tag(codes['ISO-639-1'] or iso6393_code)
+            # RFC-5646 (Same as IETF BCP 47)
+            codes['RFC-5646'] = codes['IETF-BCP-47']
+            # CLDR (Common Locale Data Repository)
+            codes['CLDR'] = codes['IETF-BCP-47']
+            # Ethnologue, SIL, LC codes
+            codes['Ethnologue'] = iso6393_code
+            codes['SIL'] = iso6393_code.upper()
+            codes['LC'] = codes['ISO-639-2/B'] or codes['ISO-639-3']
+
+        else:
+            # If language not found
+            codes['name'] = 'Unknown'
+    except Exception as e:
+        # Handle parsing errors
+        codes['name'] = 'Unknown'
+        print(f"Error processing code {flores_code}: {e}")
+    return codes
+
+# Build the languages data structure
+languages_list = []
+for flores_code in flores_codes:
+    codes = get_language_codes(flores_code)
+    languages_list.append(codes)
+
+@get("/languages")
+def languages(
+    standardization: Annotated[
+        Optional[Standardization],
+        Parameter(
+            description="Standardization code to sort the languages by.",
+            examples=[
+                Example(
+                    summary="Sort by name",
+                    description="Sorting by name is the default.",
+                    value="",
+                ),
+                Example(
+                    summary="Sort by IETF codes",
+                    description="Use IETF-BCP-47 standardization for sorting.",
+                    value="IETF-BCP-47",
+                ),
+                Example(
+                    summary="Sort by ISO-639-1 codes",
+                    description="Use ISO-639-1 standardization for sorting.",
+                    value="ISO-639-1",
+                ),
+                Example(
+                    summary="Sort by RFC-5646 codes",
+                    description="Use RFC-5646 standardization for sorting.",
+                    value="RFC-5646",
+                ),
+                Example(
+                    summary="Sort by ISO-15924 script codes",
+                    description="Use ISO-15924 script standardization for sorting by script code.",
+                    value="ISO-15924",
+                ),
+                Example(
+                    summary="Sort by ISO-639-3 codes",
+                    description="Use ISO-639-3 standardization for sorting by language codes.",
+                    value="ISO-639-3",
+                ),
+                Example(
+                    summary="Sort by Ethnologue codes",
+                    description="Use Ethnologue standardization for sorting by Ethnologue language codes.",
+                    value="Ethnologue",
+                ),
+                Example(
+                    summary="Sort by SIL codes",
+                    description="Use SIL standardization for sorting by SIL language codes.",
+                    value="SIL",
+                ),
+            ],
+        ),
+    ] = None,
+) -> Dict[Union[Languages, Standardization], Dict[Standardization, str]]:
+    if standardization and standardization in languages_list[0]:
+        # Sort by the specified standardization code
+        result = {
+            lang[standardization]: {key: value for key, value in lang.items() if key != standardization}
+            for lang in languages_list
+            if lang.get(standardization)
+        }
+    else:
+        # Default sorting by language name
+        result = {
+            lang["name"]: {key: value for key, value in lang.items() if key != "name"}
+            for lang in languages_list
+        }
+    return result
+
+app = Litestar(route_handlers=[languages])
+

--- a/server/types/__init__.py
+++ b/server/types/__init__.py
@@ -1,3 +1,4 @@
 from server.types.compute_types import ComputeTypes as ComputeTypes
 from server.types.devices import Devices as Devices
 from server.types.languages import Languages as Languages
+from server.types.standardization import Standardization as Standardization

--- a/server/types/standardization.py
+++ b/server/types/standardization.py
@@ -1,0 +1,16 @@
+from typing import Literal
+
+type Standardization = Literal[
+    'FLORES-200',
+    'ISO-639-3',
+    'ISO-15924',
+    'name',
+    'ISO-639-1',
+    'ISO-639-2/B',
+    'IETF-BCP-47',
+    'RFC-5646',
+    'CLDR',
+    'Ethnologue',
+    'SIL',
+    'LC',
+]


### PR DESCRIPTION
There are many language code standardizations, such as [FLORES-200](https://github.com/facebookresearch/flores/blob/main/flores200/README.md), [ISO-639-3](https://iso639-3.sil.org/code_tables/639/data), and [IETF-BCP-47](https://www.techonthenet.com/js/language_tags.php). Different libraries use different standards, and it can be difficult to map between them.

To address this, I have added a `/languages` endpoint to the API, which can be sorted by a specific standard using a query parameter, such as `/languages?standardization=IETF-BCP-47`. This will help users of the API easily retrieve the language code standardization they need for further processing.

For example, in a live audio translation service I’m working on, the Whisper library returns language codes that are not in FLORES-200, requiring conversion to another format. Furthermore, when displaying the results on a website, I need a different format since the site Im working with doesn't support FLORES-200. Mapping these codes manually is tedious, which is why I added this feature to simplify the process for everyone.

Additionally, the `/languages` endpoint provides a list of all supported translations in this API, allowing users to quickly determine which languages are available for translation and how to convert between different language code standards.